### PR TITLE
Update using_datasets.md

### DIFF
--- a/docs/home/using_datasets.md
+++ b/docs/home/using_datasets.md
@@ -77,6 +77,10 @@ To use a public or your personal dataset in your project you can use
 the `--data` parameter in the floyd [run](../commands/run.md) command.
 The data will be mounted and available in `/input` directory at project during run time.
 
+Note: Here, you just want to use 'ls -la /input' to view the data. But, at first, floyd will upload all of 
+the data in current directory. The proposal is to make an empyt project and init it, then run the follow 
+command in that empty directory.
+
 ```bash
 $ floyd run --data GY3QRFFUA8KpbnqvroTPPW "ls -la /input"
 Syncing code ...


### PR DESCRIPTION
When I run the command '$ floyd run --data GY3QRFFUA8KpbnqvroTPPW "ls -la /input"', floyd will syncing all of data in the current directory.  If the directory have 1GB data ？ No need. So my suggestion is to modify the floyd command not uploading data when the command is just shell command. But now, we can make an empty project to avoid it.