### PR TITLE
Update storing output docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 site
 .DS_Store
+*.sw[op]

--- a/docs/guides/data/storing_output.md
+++ b/docs/guides/data/storing_output.md
@@ -24,7 +24,7 @@ $ floyd run "echo 'Hello, world!' > /output/hello.txt"
 Syncing code ...
 ```
 
-!!! important
+!!! note
     If you are not familiar with what
     `echo 'Hello, world!' > /output/hello.txt` does, here's a quick
     explanation:

--- a/docs/guides/data/storing_output.md
+++ b/docs/guides/data/storing_output.md
@@ -1,17 +1,17 @@
 #### Overview
-Saving information generated during a run is easy.
+Saving information generated during a job is easy.
 
 On a FloydHub deep learning server your code has access to a directory called
 `/output`. The `/output` directory is a special directory that is used to store
 information you want to save for future use after a job finishes. Anything
-saved in the `/output` directory at the time a run finishes will be preserved
+saved in the `/output` directory at the time a job finishes will be preserved
 and can be accessed and reused later.
 
 The most common thing users save is model checkpoints, but anything that ends
-up in the `/output` directory at the end of a run will be saved (use your
+up in the `/output` directory at the end of a job will be saved (use your
 imagination!).
 
-Let's work through a couple of examples to see how to save data during a run.
+Let's work through a couple of examples to see how to save data during a job.
 
 #### Example 1
 This job prints the string "Hello, world!", and saves it to a file called

--- a/docs/guides/data/storing_output.md
+++ b/docs/guides/data/storing_output.md
@@ -1,29 +1,84 @@
-Most jobs generate output files (eg. model checkpoints, logs, evaluation output). In Floyd, `/output` is a special directory used to store outputs. 
+#### Overview
+Saving information generated during a run is easy.
 
-Any file or directory you create at runtime under the `/output` directory will be retained and available to you for download after your job finishes.
+On a FloydHub deep learning server your code has access to a directory called
+`/output`. The `/output` directory is a special directory that is used to store
+information you want to save for future use after a job finishes. Anything
+saved in the `/output` directory at the time a run finishes will be preserved
+and can be accessed and reused later.
+
+The most common thing users save is model checkpoints, but anything that ends
+up in the `/output` directory at the end of a run will be saved (use your
+imagination!).
+
+Let's work through a couple of examples to see how to save data during a run.
 
 #### Example 1
-
-This job runs a Python script called `helloworld.py` and redirects its output logs into the file `/output/my-output-file.txt`:
+This job prints the string "Hello, world!", and saves it to a file called
+`hello.txt`. Because `hello.txt` is located in the `/output` directory, it will
+be saved and available after the job finishes:
 
 ```bash
-$ floyd init quick-start
-$ floyd run "python helloworld.py > /output/my-output-file.txt"
+$ floyd init my_awesome_hello_world_project
+$ floyd run "echo 'Hello, world!' > /output/hello.txt"
 Syncing code ...
-...
 ```
 
-*NOTE*: This is a simple example that only stores the standard output of `helloworld.py`. Since the file is created under the special `/output` directory, it will be saved even after your job has ended. 
+!!! important
+    If you are not familiar with what
+    `echo 'Hello, world!' > /output/hello.txt` does, here's a quick
+    explanation:
 
+    The `echo 'Hello, world!'` part outputs the string `Hello, world!`. The `>`
+    part of the command redirects the printed output of `echo ‘Hello, world!'`
+    (which is, of course, `Hello world!`) to the file specified after the `>`.
+    In this case, we redirect to a file located at `/output/hello.txt`.
+    Because `hello.txt` is in the `/output` directory, it will be preserved for
+    future reference and use.
 
 #### Example 2
+In this example, we'll use Python to save some data to a file in the `/output`
+directory. Put this code in a file named `save_example.py`:
 
-If you want to save and retain your model checkpoints and other data inside your code, you should write them to `/output`.
+```python
+with open('/output/myfile.txt', 'a') as f:
+    f.write('Please save me!\n')
+```
 
-Here is a sample Tensorflow example that saves the model weights:
+If you run this code locally on your computer, you'll probably get something
+like this:
 
-`save_restore_model.py`
 ```bash
+Traceback (most recent call last):
+  File "save_example.py", line 1, in <module>
+    with open('/output/myfile.txt', 'a') as f:
+IOError: [Errno 2] No such file or directory: '/output/myfile.txt'
+```
+
+That's because there is no `/output` directory on your computer. In contrast,
+every job on FloydHub runs on a server that has a `/output` directory, so the
+command won't fail on FloydHub. Let's run it with the following commands:
+
+```bash
+$ floyd init save_example_2
+$ floyd run "python save_example.py"
+Creating project run. Total upload size: 267.0B
+Syncing code ...
+```
+Success! We can now view the output, download it, or even use it again in
+future jobs.
+
+Now that we've completed a couple trivial examples, let's do something more
+useful and realistic.
+
+#### Example 3
+Here is a sample Tensorflow example that saves a model checkpoint. Because we
+write (save) the data to the `/output` directory, we'll be able to use it
+later. A future job can use this model checkpoint as a starting point.
+Consider this partial code, and note the call to `saver.save(sess,
+‘/output/model.ckpt')`:
+
+```python
 import tensorflow as tf
 
 ...
@@ -37,22 +92,23 @@ with tf.Session() as sess:
     ...
 ```
 
-Again, since the model is stored under the special `/output` directory, they will be saved even after your job ends. 
-
-You can view or refer to this output using the [floyd output](../../commands/output) command
+Because model is stored under the special `/output` directory, it will be saved
+even after your job ends, and can be used again in future jobs. You can view
+this output using the `floyd output` command:
 
 ```bash
 $ floyd output floydhub/projects/quick-start/1/output
 Opening output directory in your browser...
 ```
 
-Alternatively, you can visit the `Output` tab of the job on your dashboard
+Alternatively, you can browse or download the saved output by visiting the
+`Output` tab of the job on your dashboard as shown in the image below:
 
 ![Job Output View](../../img/job_output_view.jpg)
 
+#### Using output as a data source
 
-## Using output as a data source
-
-You can use the output of one job as the input to your next job. To see how to mount output data, please see [this guide](./mounting_data#mounting-the-output-of-another-job)
+You can use the output of one job as the input to your next job. To see how to
+mount output data, please see [this guide](./mounting_data#mounting-the-output-of-another-job)
 
 {!contributing.md!}

--- a/docs/guides/data/storing_output.md
+++ b/docs/guides/data/storing_output.md
@@ -94,11 +94,13 @@ with tf.Session() as sess:
 ```
 
 Because model is stored under the special `/output` directory, it will be saved
-even after your job ends, and can be used again in future jobs. You can view
-this output using the `floyd output` command:
+even after your job ends, and can be used again in future jobs.
+
+#### Viewing Saved Output Data
+You can view the saved output of a job using the `floyd output` command:
 
 ```bash
-$ floyd output floydhub/projects/quick-start/1/output
+$ floyd output floydhub/projects/quick-start/1/
 Opening output directory in your browser...
 ```
 

--- a/docs/guides/data/storing_output.md
+++ b/docs/guides/data/storing_output.md
@@ -29,12 +29,13 @@ Syncing code ...
     `echo 'Hello, world!' > /output/hello.txt` does, here's a quick
     explanation:
 
-    The `echo 'Hello, world!'` part outputs the string `Hello, world!`. The `>`
-    part of the command redirects the printed output of `echo ‘Hello, world!'`
-    (which is, of course, `Hello world!`) to the file specified after the `>`.
-    In this case, we redirect to a file located at `/output/hello.txt`.
-    Because `hello.txt` is in the `/output` directory, it will be preserved for
-    future reference and use.
+    - The `echo 'Hello, world!'` part outputs the string `Hello, world!`.
+    - The `>` part of the command redirects the printed output of `echo 'Hello, world!'`
+      (which is, of course, `Hello world!`) to the file specified after the `>`.
+    - The `/output/hello.txt` part of the command specifies where the `Hello,
+      world!` should be written to: `/output/hello.txt`. Because `hello.txt` is
+      in the `/output` directory, it will be preserved for future reference and
+      use.
 
 #### Example 2
 In this example, we'll use Python to save some data to a file in the `/output`
@@ -76,7 +77,7 @@ Here is a sample Tensorflow example that saves a model checkpoint. Because we
 write (save) the data to the `/output` directory, we'll be able to use it
 later. A future job can use this model checkpoint as a starting point.
 Consider this partial code, and note the call to `saver.save(sess,
-‘/output/model.ckpt')`:
+'/output/model.ckpt')`:
 
 ```python
 import tensorflow as tf

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,5 @@
 ## Introduction
-Welcome to [FloydHub](https://www.floydhub.com/)! Here you'll find comprehensive information for training and deploying your deep learning and AI applications with our platform. We've tried to make this documentation user-friendly and example-filled, but if you have any questions, please visit the [community forum](https://forum.floydhub.com/) or [contact us](mailto:support@floydhub.com).
+Welcome to [FloydHub](https://www.floydhub.com/)! Here you'll find comprehensive information for training and deploying your deep learning and AI applications with our platform. We do our best to make this documentation clear and user friendly, but if you have unanswered questions, please visit the [community forum](https://forum.floydhub.com/) or [contact us](mailto:support@floydhub.com).
 
 The fastest way to get up and running is to use our [quickstart guide](http://docs.floydhub.com/getstarted/quick_start), which walks through an entire FloydHub training job step-by-step. You'll create a new Project on the FloydHub web dashboard, connect it to a local directory on your computer, and then kick-off a job using the FloydHub CLI to train your deep learning model on FloydHub's GPU servers.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,35 +7,34 @@ pages:
     - Get Started:
         - 'Quick Start': getstarted/quick_start.md
         - 'Jupyter Notebook': getstarted/quick_start_jupyter.md
-    - Guides:
-        - Basics:
-            # - 'Core concepts': guides/basics/core_concepts.md
-            - 'Install Floyd CLI': guides/basics/install.md
-            - 'Login using Floyd CLI': guides/basics/login.md
-            - 'Create new Project and Dataset': guides/basics/create_new.md
-            - 'Delete Project, Jobs and Data': guides/basics/delete.md
-            - 'Using CPU vs GPU': guides/basics/using_gpu.md
-        - Jobs:
-            - 'Installing extra dependencies': guides/jobs/installing_dependencies.md
-            - 'Enabling Tensorboard': guides/jobs/tensorboard.md
-        - Data:
-            - 'Storing output data': guides/data/storing_output.md
-            - 'Mounting data': guides/data/mounting_data.md
-            - 'Symlink mounted data': guides/data/symlink_mounted_data.md
+    - Basics:
+        # - 'Core concepts': guides/basics/core_concepts.md
+        - 'Install Floyd CLI': guides/basics/install.md
+        - 'Login using Floyd CLI': guides/basics/login.md
+        - 'Create new Project and Dataset': guides/basics/create_new.md
+        - 'Delete Project, Jobs and Data': guides/basics/delete.md
+        - 'Using CPU vs GPU': guides/basics/using_gpu.md
+    - Jobs:
+        - 'Installing extra dependencies': guides/jobs/installing_dependencies.md
+        - 'Enabling Tensorboard': guides/jobs/tensorboard.md
         - 'Environments': guides/environments.md
         - 'Ignore files': guides/floyd_ignore.md
-        
+    - Data:
+        - 'Storing output data': guides/data/storing_output.md
+        - 'Mounting data': guides/data/mounting_data.md
+        - 'Symlink mounted data': guides/data/symlink_mounted_data.md
+
     - Examples:
         - 'Style Transfer': examples/style_transfer.md
         - 'Deep Text Corrector': examples/deep_corrector.md
-    - FAQs:
-        - 'Installation FAQs': faqs/installation.md
-        - 'Signup and Login FAQs': faqs/authentication.md
-        - 'Job FAQs': faqs/job.md
-        - 'Environments FAQs': faqs/environments.md
-        - 'Plans FAQs': faqs/plans.md
-        - 'Billing FAQs': faqs/billing.md
-    - Commands:
+    - Troubleshooting & FAQs:
+        - 'Installation': faqs/installation.md
+        - 'Signup and Login': faqs/authentication.md
+        - 'Job': faqs/job.md
+        - 'Environments': faqs/environments.md
+        - 'Plans': faqs/plans.md
+        - 'Billing': faqs/billing.md
+    - Floyd CLI Commands:
         - 'floyd': commands/index.md
         - 'floyd login': commands/login.md
         - 'floyd init': commands/init.md


### PR DESCRIPTION
@saiprashanths  The changes in `mkdocs.yml` don't mess with the URLs, they just update the sidebar to exclude the `Guides` level. So no links will be broken by these changes.

I have forked the repo and am serving my version (the code behind this PR) on my own github pages branch. You can see my changes [here](https://mckayward.github.io/floyd-docs/guides/data/storing_output/)