### PR TITLE
add docs for floyd login --token

### DIFF
--- a/docs/guides/basics/login.md
+++ b/docs/guides/basics/login.md
@@ -1,12 +1,11 @@
-## Login using floyd-cli
-
 ### Quick Preparation Checklist
 
 - You must have a [FloydHub account](https://www.floydhub.com/signup)
 - You must be [logged in to your web dashboard](https://www.floydhub.com/login)
 - You must have `floyd-cli` [installed on your computer](install.md)
 
-You can use the [floyd login](../../commands/login.md) command to login to your FloydHub account through your command line
+You can use the [floyd login](../../commands/login.md) command to log in to
+your FloydHub account through your command line
 
 ```bash
 $ floyd login
@@ -15,14 +14,32 @@ Please copy and paste the authentication token.
 This is an invisible field. Paste token and press ENTER:
 ```
 
-This will open your browser and display your authentication token. You can also access this directly at [floydhub.com/settings/security](https://www.floydhub.com/settings/security). (*Note:* only visible if you are [logged in](https://www.floydhub.com/login) to your web dashboard). 
+This will open your browser and display your authentication token. You can also
+access this directly at
+[floydhub.com/settings/security](https://www.floydhub.com/settings/security).
+(*Note:* only visible if you are [logged in](https://www.floydhub.com/login) to
+your web dashboard).
 
 ![Windows 10 Login](../../img/login_token.jpg)
 
 Copy the token and paste it in your terminal.
 
+### Logging in without opening a browser
+
+Sometimes you may need to log in to Floyd on a computer that can't open a
+browser. Using your
+[token from floydhub.com](https://www.floydhub.com/settings/security), you can
+log in without opening a browser by passing the `--token` flag to
+`floyd login`:
+
+```
+$ floyd login --token
+Please copy and paste the authentication token.
+This is an invisible field. Paste token and press ENTER:
+Login Successful
+```
+
 ### Having problems with logging in using floyd-cli?
 
-- If you cannot open your browser from the terminal (e.g. you are SSH-ing into a remote server), use the `--token` flag. See [floyd login](../../commands/login.md) for more details
 - Are you on a Windows machine? Please see our [FAQs for Windows](../../faqs/authentication.md#windows)
 - Other problems? Check out our [Login FAQs](../../faqs/authentication.md#login) or [contact us](mailto:support@floydhub.com)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,8 +10,8 @@ pages:
     - Basics:
         # - 'Core concepts': guides/basics/core_concepts.md
         - 'Install Floyd CLI': guides/basics/install.md
-        - 'Login using Floyd CLI': guides/basics/login.md
-        - 'Create new Project and Dataset': guides/basics/create_new.md
+        - 'Log In Using Floyd CLI': guides/basics/login.md
+        - 'Create New Project and Dataset': guides/basics/create_new.md
         - 'Delete Project, Jobs and Data': guides/basics/delete.md
         - 'Using CPU vs GPU': guides/basics/using_gpu.md
     - Jobs:


### PR DESCRIPTION
Also corrects usage of login vs log in. This is not live on my fork's github pages yet, since the Data Mounting PR is more important, and I don't want to mix up my braches :slightly_smiling_face: 