### PR TITLE
open Basics Jobs and Data nav items by default

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,7 @@ site_name: FloydHub
 site_url: https://www.floydhub.com
 site_author: FloydHub Team
 repo_url: https://github.com/floydhub/floyd-docs
+theme_dir: 'theme_overrides'
 pages:
     - Home: index.md
     - Get Started:
@@ -52,6 +53,10 @@ pages:
         - 'floyd version': commands/version.md
 theme: material
 extra:
+  nav_items_open_by_default:
+    - Basics
+    - Jobs
+    - Data
   palette:
     primary: 'blue'
     accent: 'blue'

--- a/theme_overrides/partials/nav-item.html
+++ b/theme_overrides/partials/nav-item.html
@@ -1,0 +1,54 @@
+{% set class = "md-nav__item" %}
+{% if nav_item.active %}
+  {% set class = "md-nav__item md-nav__item--active" %}
+{% endif %}
+{% if nav_item.children %}
+  <li class="{{ class }} md-nav__item--nested">
+    {% if nav_item.active or nav_item.title in config.extra.nav_items_open_by_default %}
+      <input class="md-toggle md-nav__toggle" data-md-toggle="{{ path }}" type="checkbox" id="{{ path }}" checked>
+    {% else %}
+      <input class="md-toggle md-nav__toggle" data-md-toggle="{{ path }}" type="checkbox" id="{{ path }}">
+    {% endif %}
+    <label class="md-nav__link" for="{{ path }}">
+      {{ nav_item.title }}
+    </label>
+    <nav class="md-nav" data-md-component="collapsible" data-md-level="{{ level }}">
+      <label class="md-nav__title" for="{{ path }}">
+        {{ nav_item.title }}
+      </label>
+      <ul class="md-nav__list" data-md-scrollfix>
+        {% set base = path %}
+        {% for nav_item in nav_item.children %}
+          {% set path = base + "-" + loop.index | string %}
+          {% set level = level + 1 %}
+          {% include "partials/nav-item.html"  %}
+        {% endfor %}
+      </ul>
+    </nav>
+  </li>
+{% elif nav_item == page %}
+  <li class="{{ class }}">
+    {% set toc_ = page.toc %}
+    <input class="md-toggle md-nav__toggle" data-md-toggle="toc" type="checkbox" id="toc">
+    {% if toc_ | first is defined and "\x3ch1 id=" in page.content %}
+      {% set toc_ = (toc_ | first).children %}
+    {% endif %}
+    {% if toc_ | first is defined %}
+      <label class="md-nav__link md-nav__link--active" for="toc">
+        {{ nav_item.title }}
+      </label>
+    {% endif %}
+    <a href="{{ nav_item.url }}" title="{{ nav_item.title }}" class="md-nav__link md-nav__link--active">
+      {{ nav_item.title }}
+    </a>
+    {% if toc_ | first is defined %}
+      {% include "partials/toc.html" %}
+    {% endif %}
+  </li>
+{% else %}
+  <li class="{{ class }}">
+    <a href="{{ nav_item.url }}" title="{{ nav_item.title }}" class="md-nav__link">
+      {{ nav_item.title }}
+    </a>
+  </li>
+{% endif %}


### PR DESCRIPTION
@saiprashanths This opens up the sidebar categories we talked about. I think the sidebar is going to be changing soon anyways, but I think this is a nice improvement in the interim. You can see it working [here](https://mckayward.github.io/floyd-docs/)