### PR TITLE
Update env name in the command

### DIFF
--- a/docs/getstarted/quick_start_jupyter.md
+++ b/docs/getstarted/quick_start_jupyter.md
@@ -63,7 +63,7 @@ Starting a Jupyter Notebook on FloydHub is very simple. Use the [floyd run](../c
 Execute the following command from the command line:
 
 ```bash
-$ floyd run --mode jupyter --gpu --env pytorch
+$ floyd run --mode jupyter --gpu --env pytorch-0.2
 Creating project run. Total upload size: 21.9KiB
 Syncing code ...
 [================================] 23333/23333 - 00:00:00


### PR DESCRIPTION
I tried the command `floyd run --mode jupyter --gpu --env pytorch` written in the doc, but it didn't work. So I checked the list of environments you provide and modify `pytorch` to one of the env parameters you wrote, `pytorch-0.2`, and it worked well.