### PR TITLE
Update the quickstart

### DIFF
--- a/docs/getstarted/quick_start.md
+++ b/docs/getstarted/quick_start.md
@@ -56,13 +56,13 @@ Cloning into 'quick-start'...
 ...
 $ cd quick-start
 $ ls
-LICENSE    mnist_cnn.py    mnist_cnn.ipynb    README.md
+eval.py  LICENSE  mnist_cnn.ipynb  README.md  train_and_eval.py  train.py
 ```
 
-This repository contains a file we'll use to get started: `mnist_cnn.py`. It's
-a Python script that trains a convolutional neural network model against the
-MNIST dataset. Feel free to look through the file if you'd like, but you don't
-need to.
+This repository contains a file we'll use to get started: `train.py`.
+It's a Python script that trains a convolutional neural network model against
+the MNIST dataset. Feel free to look through the file if you'd like, but you
+don't need to.
 
 #### Initialize the Project Locally
 
@@ -87,7 +87,7 @@ dataset. You probably know that the MNIST dataset is actually available within
 the TensorFlow package itself, but for the purposes of this tutorial we have
 separated out the dataset so you can get a feel for what it's like to work
 with datasets on FloydHub. We have the MNIST dataset pulicly available on
-FloydHub [here]().
+FloydHub [here](https://www.floydhub.com/mckay/datasets/mnist).
 
 !!! note
 
@@ -122,7 +122,7 @@ $ floyd run \
 --gpu \
 --data mckay/datasets/mnist/1:/mnist \
 --env tensorflow-1.3 \
-"python mnist_cnn_train.py"
+"python train.py"
 
 Creating project run. Total upload size: 25.4KiB
 Syncing code ...
@@ -143,7 +143,7 @@ Behind the scenes, FloydHub does the following:
 - Provisions a GPU instance on the cloud (because you set the `--gpu` flag)
 - Sets up a deep learning environment with GPU drivers and TensorFlow 1.3
   installed (because you set the enviroment flag to `--env tensorflow-1.3`)
-- Executes the command `python mnist_cnn.py` inside this environment
+- Executes the command `python train.py` inside this environment
 - Stores the output logs and generated output data
 - Terminates the GPU instance once the command finishes execution
 
@@ -161,9 +161,10 @@ on instance types [here](../../guides/run_a_job/#instance-type).
 
 ### --data mckay/datasets/mnist/1:/mnist
 
-The `mnist_cnn.py` script expects the MNIST data to be located at `/mnist` on
-the computer where the script runs. We can use the `--data` flag to ensure that
-our dataset is available to our code at `/mnist`.
+The `train.py` script expects the [MNIST
+data](https://www.floydhub.com/mckay/datasets/mnist/1) to be located at
+`/mnist` on the computer where the script runs. We can use the `--data` flag to
+ensure that our dataset is available to our code at `/mnist`.
 
 We pass the `--data` flag the name of our dataset (`mckay/datasets/mnist/1`)
 and the location on the server where we want our dataset to be available
@@ -183,7 +184,7 @@ When you're ready to dive in, take a read through it [here](../../guides/data/mo
 Ensures our job is run on a server that has TensorFlow 1.3 installed. More info
 on job environments [here](../../guides/run_a_job/#environment)
 
-### "python mnist_cnn_train.py"
+### "python train.py"
 
 The command we want the server to execute to kick off our code. More info
 on how to specify commands [here](../../guides/run_a_job/#command_1).
@@ -238,10 +239,9 @@ accuracy of our model.
 
 Using the `-t` (tail) flag will stream the logs as they are generated.
 
-You can also view the logs in your browser using your `Job URL`. However, the
-logs in the Dashboard are not currently refreshed dynamically, so you'll need
-to refresh your browser periodically or press `F5` to get the latest logs from
-the Dashboard.
+You can also view the logs in your browser using your `Job URL`. (The `Job URL`
+will look something like
+`https://www.floydhub.com/<username>/projects/quick-start/<job_number>`.)
 
 ## Storing Your Model for Future Use
 
@@ -250,10 +250,16 @@ on it or to check its accuracy using an evaluation script.
 
 To save something during our job that we want to save for later, we just need
 to make sure it gets saved at `/output` during our job. Anything in `/output`
-at the end of a job will be saved for us and we can reuse it later. Take a look
-at [line 108](https://github.com/floydhub/quick-start/blob/master/mnist_cnn_train.py#L108)
-in our `mnist_cnn_train.py` script. With that line, we store our model under
-`/output`, which means that FloydHub will save it for us to use later.
+at the end of a job will be saved for us and we can reuse it later.  Take a
+look at [line
+108](https://github.com/floydhub/quick-start/blob/master/train.py#L108) of our
+`train.py` script. Here's the line:
+
+```
+builder = tf.saved_model.builder.SavedModelBuilder("/output/cnn_model")
+```
+We're setting up our model to be saved under `/output`. This ensures that
+FloydHub will save it for us to use later.
 
 For more details on how to save and reuse job output, see
 [this article](../../guides/data/storing_output).
@@ -264,7 +270,7 @@ Now let's evaluate our model by checking it against our evaluation script.
 
 To finish off this tutorial, we'll evaluate the model we trained in our first
 job. The repository we cloned early has a script we can use to do this:
-`mnist_cnn_eval.py`.
+`eval.py`.
 
 The script expects our model to be located at `/model` on the machine where the
 script runs. Somehow we've got to make sure that the model we saved in our
@@ -304,8 +310,25 @@ $ floyd run \
 --env tensorflow-1.3 \
 --data mckay/datasets/mnist/1:/mnist \
 --data alice/projects/quick-start/1/output:/model \
-'python mnist_cnn_eval.py'
+'python eval.py'
+
+Creating project run. Total upload size: 26.3KiB
+Syncing code ...
+[================================] 28620/28620 - 00:00:01
+
+JOB NAME
+---------------------------
+mckay/projects/quick-start/2
+
+To view logs enter:
+   floyd logs mckay/projects/quick-start/2
 ```
+
+You know how to check the logs, so go ahead and check the logs of your second
+job and see how accurate your model is!
+
+If you forgot how to check the logs, take a look at [this
+section](#viewing-your-jobs-logs) of the page.
 
 ## Iterating on Your Model
 

--- a/docs/getstarted/quick_start.md
+++ b/docs/getstarted/quick_start.md
@@ -1,119 +1,224 @@
 ## Introduction
 
-With this quickstart guide, we've tried to make it as easy as possible to get up and running with FloydHub.
+With this quickstart guide, you'll get acquainted with FloydHub and learn the
+basics necessary to get up and running on the platform.
 
-We'll start with an overview of FloydHub and then jump into running your first job using TensorFlow and the MNIST dataset (better known as the "Hello, world!" of data science). We'll be training a convolutional neural network (CNN) model to recognize hand-written digits using FloydHub's GPU servers. For more details on the data and the model, please refer to the [Tensorflow documentation](https://www.tensorflow.org/get_started/mnist/pros).
+We'll start with an overview of FloydHub and then jump into training your first
+deep learning model on FloydHub using TensorFlow and the MNIST dataset (better
+known as the "Hello, world!" of data science). We'll be training a
+convolutional neural network (CNN) model to recognize hand-written digits using
+FloydHub's GPU servers. For more details on the data and the model, please
+refer to the [TensorFlow
+documentation](https://www.tensorflow.org/get_started/mnist/pros).
 
-## Platform overview
-
-To help you get oriented with FloydHub, let's start by defining some basics:
-
-### Tools
-
-- **[`floyd-cli`](/guides/basics/install.md)**: Convenient command line tool to interact with FloydHub from your terminal
-- **[Dashboard](https://www.floydhub.com/projects)**: Website to create, monitor, and explore Projects and Datasets
-
-### Features
-
-- **Job**: Command executed from the `floyd-cli` with optional configurations (including mounting Datasets, importing libraries like TensorFlow or PyTorch, running in Jupyter Notebook mode, or processing on GPU instances)
-- **Project**: Collection of Jobs and their corresponding code, Datasets, logs, and results
-- **[Dataset](/guides/data/mounting_data/)**: Input data that can be connected to a Project via a Job
-
-## Setting up your first Project on FloydHub
-
-### Quick preparation checklist
+## Quick Preparation Checklist
 - [Create a FloydHub account](https://www.floydhub.com/login)
 - [Install `floyd-cli` on your computer](../guides/basics/install.md)
 - [Log in to FloydHub through `floyd-cli`](../guides/basics/login.md)
 
-### Get the code
-Clone the [quick-start repository](https://github.com/floydhub/quick-start) from GitHub onto your computer.
+## Create a New Project
+First, we'll need to [create a project](../guides/basics/create_new). All the
+[jobs](../getstarted/core_concepts/#jobs) we run while training our model will
+be grouped under this project, and we'll be able to go back and review each job
+later. For more information about projects, check out our [Core Concepts
+page](../getstarted/core_concepts/#projects).
+
+To create the project, visit [www.floydhub.com/projects](), and click the
+`New Project` button in the top right corner of the screen. Complete the form
+to create a new project. (Note that private projects are only available on our
+[Data Scientist Plans](https://www.floydhub.com/pricing).)
+
+If you're a new user, then you should already see a default project named
+`quick-start` in your [projects dashboard](https://www.floydhub.com/projects). If you don't see it, go ahead and create a project named 'quick-start'.
+
+When you visit [www.floydhub.com/projects]() you should see your quick-start
+project, as shown below:
+
+![Quick start project](../img/quick_start_project.jpg)
+
+### Initialize the Project on Your Machine
+
+Now that we've created the project on FloydHub, we can use Floyd CLI to start
+getting some deep learning done. We'll start by initializing our quick-start
+project on our local machine.
+
+#### Clone the quick-start Repo from GitHub
+
+If you were writing code from scratch, you would create a new directory on your
+computer and initialize the FloydHub project in there. In this quick start,
+we'll clone an existing GitHub repository and use its code. Clone the
+[quick-start repository](https://github.com/floydhub/quick-start) from GitHub
+onto your computer, and change directories into it:
 
 ```bash
 $ git clone https://github.com/floydhub/quick-start.git
 Cloning into 'quick-start'...
 ...
 $ cd quick-start
-```
-
-```bash
 $ ls
 LICENSE    mnist_cnn.py    mnist_cnn.ipynb    README.md
 ```
 
-This repository contains two important files: `mnist_cnn.py` (a Python script to train a convolutional neural network model against the MNIST dataset) and `mnist_cnn.ipynb` (a Jupyter Notebook to interactively explore the MNIST dataset). 
+This repository contains a file we'll use to get started: `mnist_cnn.py`. It's
+a Python script that trains a convolutional neural network model against the
+MNIST dataset. Feel free to look through the file if you'd like, but you don't
+need to.
 
-In this quickstart tutorial, we'll only be using the Python script. Our separate [Jupyter Notebook tutorial](/getstarted/quick_start_jupyter.md) explains how to run this Project in Jupyter Notebook mode.
+#### Initialize the Project Locally
 
-### Initialize your Project
-If you're a new user, then you should already see a default Project named `quick-start` in your [Projects dashboard](https://www.floydhub.com/projects).
+To "initialize" a FloydHub project on your machine
+means to run the `floyd init <name_of_project>` command in your project's
+directory. This will create some files in the directory that Floyd CLI uses to
+keep track of your jobs and sync with floydhub.com.
 
-![Quick start project](../img/quick_start_project.jpg)
-
-Alternatively, you can simply create a new Project named `quick-start` in the FloydHub Dashboard with these [instructions](../guides/basics/create_new/#create-a-new-project).
-
-We'll need to link the Python model-training code with your `quick-start` Project on FloydHub. Use the `floyd init` command in the current directory of your terminal to initialize your Project. 
+Let's initialize our project inside of the directory we just cloned from
+GitHub:
 
 ```bash
 $ floyd init quick-start
 Project "quick-start" initialized in the current directory
 ```
+Success!
 
-This tells FloydHub that all the Jobs you run from this local directory belong to your Project named `quick-start`.
+## Get the Dataset
 
-## Running your first Job
+To run our deep-learning script, we'll need to give it access to the MNIST
+dataset. You probably know that the MNIST dataset is actually available within
+the TensorFlow package itself, but for the purposes of this tutorial we have
+separated out the dataset so you can get a feel for what it's like to work
+with datasets on FloydHub. We have the MNIST dataset pulicly available on
+FloydHub [here]().
 
-Running a job on FloydHub is simple - when you use the `floyd run` command, the `floyd-cli` tool syncs your code with FloydHub's servers and runs the command in the cloud. 
+!!! note
 
-FloydHub will run any command you provide as a new Job - even a Job as simple as listing your current directory with the `ls` command. However, FloydHub is specialized for running deep learning and data science processing commands.
+    On FloydHub, datasets are kept separate from your project/code. This
+    approach serves two main purposes:
 
-For this tutorial, we'll run the `mnist_cnn.py` Python script on FloydHub's GPU servers to train our convolutional neural network model against the MNIST data.
+    - **Upload data only once**: Datasets are usually big, so we don't want to
+      have to upload them each time we run our code.
+    - **Enable collaboration**: When datasets are kept separate from code, team
+      members and communities can more easily work on projects together.
+
+    If you'd like more information on keeping data separate from code, check out
+    [this section](../getstarted/core_concepts/#why-keep-datasets-separate-from-code)
+    of our Core Concepts page.
+
+When you start working on your own projects, you'll eventually want to upload
+your own dataset. Check out
+[this article](../../guides/create_and_upload_dataset) to learn how to do that.
+
+## Running Your First Job
+
+Now that we have our project created and our dataset ready, let's run our first
+job and train our model! A [job](../getstarted/core_concepts/#jobs) is an
+execution of your code on FloydHub's deep-learning servers. To kick off a job,
+we use the `floyd run` command.
+
+Run the command below to kick off the training job. (Don't worry, we'll explain
+each piece of the command.)
 
 ```bash
-$ floyd run --gpu --env tensorflow "python mnist_cnn.py"
-Syncing code ...
-NAME               
--------------------
-alice/quick-start/1
+$ floyd run \
+--gpu \
+--data mckay/datasets/mnist/1:/mnist \
+--env tensorflow-1.3 \
+"python mnist_cnn_train.py"
 
-To view the logs enter:
-    floyd logs alice/quick-start/1
+Creating project run. Total upload size: 25.4KiB
+Syncing code ...
+[================================] 27316/27316 - 00:00:00
+
+JOB NAME
+----------------------
+alice/projects/mnist/1
+
+To view logs enter:
+   floyd logs alice/projects/mnist/1
 ```
 
-Congratulations! Your first job is now running on FloydHub's GPU servers. Behind the scenes, FloydHub does the following:
+Congratulations! Your first job is now running on FloydHub's GPU servers.
+Behind the scenes, FloydHub does the following:
 
 - Syncs your local code to FloydHub's servers
 - Provisions a GPU instance on the cloud (because you set the `--gpu` flag)
-- Sets up a deep learning environment with GPU drivers and Tensorflow installed (because you set the enviroment flag to `--env tensorflow`)
+- Sets up a deep learning environment with GPU drivers and TensorFlow 1.3
+  installed (because you set the enviroment flag to `--env tensorflow-1.3`)
 - Executes the command `python mnist_cnn.py` inside this environment
 - Stores the output logs and generated output data
 - Terminates the GPU instance once the command finishes execution
 
-## Monitoring your Job
+Here is quick explanation of each part of the command you just ran:
 
-You can view the status of your Job from your terminal using the [`floyd status`](../commands/status.md) command. You can specify a single Job name (e.g. `floyd status alice/quick-start/1`) to get its status, or the `floyd-cli` will show the status of all Jobs in the current Project.
+### floyd run
+
+Tells the CLI we want to run a job.  You'll use this command to run all of your
+jobs. [More info here](../../guides/run_a_job/#instance-type).
+
+### --gpu
+
+Specifies that we want our job run on a GPU server. More info
+on instance types [here](../../guides/run_a_job/#instance-type).
+
+### --data mckay/datasets/mnist/1:/mnist
+
+The `mnist_cnn.py` script expects the MNIST data to be located at `/mnist` on
+the computer where the script runs. We can use the `--data` flag to ensure that
+our dataset is available to our code at `/mnist`.
+
+We pass the `--data` flag the name of our dataset (`mckay/datasets/mnist/1`)
+and the location on the server where we want our dataset to be available
+(`/mnist`), separated by a colon (`:`).
+
+Putting that all together, we get:
+
+```
+--data mckay/datasets/mnist/1:/mnist
+```
+
+We have an entire article in our docs about mounting datasets to your jobs.
+When you're ready to dive in, take a read through it [here](../../guides/data/mounting_data)
+
+### --env tensorflow-1.3
+
+Ensures our job is run on a server that has TensorFlow 1.3 installed. More info
+on job environments [here](../../guides/run_a_job/#environment)
+
+### "python mnist_cnn_train.py"
+
+The command we want the server to execute to kick off our code. More info
+on how to specify commands [here](../../guides/run_a_job/#command_1).
+
+## Monitoring Your Job
+
+You can view the status of your job from your terminal using the
+[`floyd status`](../commands/status.md) command. You can specify a single job
+name (e.g. `floyd status alice/quick-start/1`) to get its status, or the
+`floyd-cli` will show the status of all jobs in the current project.
 
 ```bash
 $ floyd status
 JOB NAME             CREATED        STATUS    DURATION(s)  INSTANCE    DESCRIPTION
 -------------------  ---------      --------  -----------  ---------   -----------
-alice/quick-start:1  just now       running            15  gpu         
+alice/quick-start:1  just now       running            15  gpu
 ```
 
-You can also view the status of your job in your browser by visiting the `Job URL` printed by the `floyd run` command. For example, `https://www.floydhub.com/alice/quick-start/1`
+You can also view the status of your job in your browser by visiting the `Job
+URL` printed by the `floyd run` command. For example,
+`https://www.floydhub.com/alice/quick-start/1`. The page should look something
+like this:
 
 ![Job run](../img/job_run.jpg)
 
-### Viewing your Job's logs
+## Viewing Your Job's Logs
 
-It's easy to view the logs generated by the job from your terminal with the [floyd logs](../commands/logs.md) command. You'll need to specify the Job name in the command.
+It's easy to view the logs generated by the job from your terminal with the [floyd logs](../commands/logs.md) command. You'll need to specify the job name in the command.
 
 ```bash
 $ floyd logs -t alice/quick-start/1
 ...
 2017-07-12 16:00:07,446 INFO - Starting attempt 1 at 2017-07-12 16:00:07.436349
 2017-07-12 16:00:09,088 INFO - Starting container...
-2017-07-12 16:00:09,297 INFO - 
+2017-07-12 16:00:09,297 INFO -
 ...
 ##############################################################################
 2017-07-12 16:00:09,297 INFO - Run Output:
@@ -125,23 +230,94 @@ $ floyd logs -t alice/quick-start/1
 ...
 ```
 
-The output of your code is printed in the `Run Output` section of the logs, between the `#########` lines. Anything you log or print in your code will appear here, so this is a great way to monitor the progress of your model training command. In our `quick-start` project, we're logging the Training Accuracy of our model.
+The output of your code is printed in the `Run Output` section of the logs,
+between the `#########` lines. Anything you log or print in your code will
+appear here, so this is a great way to monitor the progress of your model
+training command. In our `quick-start` project, we're logging the training
+accuracy of our model.
 
 Using the `-t` (tail) flag will stream the logs as they are generated.
 
-You can also view the logs in your browser using your `Job URL`. However, the logs in the Dashboard are not currently refreshed dynamically, so you'll need to refresh your browser periodically or press `F5` to get the latest logs from the Dashboard.
+You can also view the logs in your browser using your `Job URL`. However, the
+logs in the Dashboard are not currently refreshed dynamically, so you'll need
+to refresh your browser periodically or press `F5` to get the latest logs from
+the Dashboard.
 
-### Viewing the Job output
+## Storing Your Model for Future Use
 
-The model that we trained in this quickstart tutorial does not save any new output models - instead it simply prints the model results to the logs. We'll explore how to save model outputs in the Jupyter Notebook tutorial.
+We want to save the model we trained so we can use it later, maybe to iterate
+on it or to check its accuracy using an evaluation script.
 
-## Iterating on your Project
+To save something during our job that we want to save for later, we just need
+to make sure it gets saved at `/output` during our job. Anything in `/output`
+at the end of a job will be saved for us and we can reuse it later. Take a look
+at [line 108](https://github.com/floydhub/quick-start/blob/master/mnist_cnn_train.py#L108)
+in our `mnist_cnn_train.py` script. With that line, we store our model under
+`/output`, which means that FloydHub will save it for us to use later.
 
-Congratulations! You've run your first job on FloydHub 🎉
+For more details on how to save and reuse job output, see
+[this article](../../guides/data/storing_output).
 
-At this point, you can edit your Python code locally to make improvements or adjustments, and then kick off a new Job with the [floyd run](../commands/run.md) command. The `floyd-cli` will upload the newest versions of your code and submit another Job to the FloydHub servers. Along the way, FloydHub will be managing and tracking of all the iterations of Jobs within your Project.
+Now let's evaluate our model by checking it against our evaluation script.
 
-You can always view details on all of the Jobs in your current Project with the `floyd status` command from your terminal, or by visiting the `Project URL` in your browser.
+## Evaluate Your Model
+
+To finish off this tutorial, we'll evaluate the model we trained in our first
+job. The repository we cloned early has a script we can use to do this:
+`mnist_cnn_eval.py`.
+
+The script expects our model to be located at `/model` on the machine where the
+script runs. Somehow we've got to make sure that the model we saved in our
+first job ends up at that location during our second job. FloydHub allows us to
+reuse a job's output in another job, and to specify the place the data will be
+located during the second job. The method to accomplish this is the same one we
+used to mount our dataset to our first job. We'll demonstrate how to mount our
+model in the next section.
+
+### How to Reuse the Output of Your Previous Job
+
+Output from previous jobs can be attached to a new job using the same approach
+as mounting a dataset. We just use the name of the output instead of the name
+of a dataset when we use the `--data` flag:
+
+```
+--data alice/projects/quick-start/1/output:/model
+```
+
+Notice that we specify `/model` as the mountpoint because we know our
+evaluation script expects our model to be at `/model`.
+
+For more information on reusing output, check out
+[this article](../../guides/reusing_output)
+
+### Run Your Second Job
+
+Follow this command to run your second job. Note that we are mounting our dataset again at `/mnist` and also mounting our model at `/model`:
+
+```
+
+$ floyd run \
+--gpu \
+--env tensorflow-1.3 \
+--data mckay/datasets/mnist/1:/mnist \
+--data alice/projects/quick-start/1/output:/model \
+'python mnist_cnn_eval.py'
+```
+
+## Iterating on Your Model
+
+Congratulations! You've trained and tested your first model on FloydHub 🎉
+
+At this point, you can edit your Python code locally to make improvements or
+adjustments to your training script, and then kick off a new job with the
+[floyd run](../commands/run.md) command. The `floyd-cli` will upload the newest
+versions of your code and submit another job to the FloydHub servers. Along the
+way, FloydHub will be managing and tracking of all the iterations of jobs
+within your project.
+
+You can always view details on all of the jobs in your current project with the
+`floyd status` command from your terminal, or by visiting the `Project URL` in
+your browser.
 
 Example: `www.floydhub.com/alice/quick-start`
 

--- a/docs/getstarted/quick_start.md
+++ b/docs/getstarted/quick_start.md
@@ -292,7 +292,10 @@ For more information on reusing output, check out
 
 ### Run Your Second Job
 
-Follow this command to run your second job. Note that we are mounting our dataset again at `/mnist` and also mounting our model at `/model`:
+Follow this command to run your second job. Note that we are mounting our
+dataset again at `/mnist` and also mounting our model at `/model`. Be sure to
+replace `mckay/projects/quickstart/1/output` with the name of the output you
+want to mount (something like `<username>/projects/quick-start/<run_number>/output`)
 
 ```
 


### PR DESCRIPTION
Proposed update to the quickstart tutorial.

This was kind of sitting stale for a bit, so I think feedback would be good. It's a fair amount longer than the old quickstart, so maybe we can get rid of some stuff if it's too tedious to get through. I am open to any feedback.

I ran through the quick-start from start to finish with the new code and descriptions and everything seems to be in line, but let me know if you see any issues.

Being served [here](mckayward.github.io/floyd-docs/getstarted/quick_start/)